### PR TITLE
fix base url oracle scripts

### DIFF
--- a/docs/technical-specifications/bandchain-cli-rest-endpoints.md
+++ b/docs/technical-specifications/bandchain-cli-rest-endpoints.md
@@ -30,7 +30,7 @@ $ curl -X GET https://api-gm-lb.bandchain.org/oracle/data_sources/1
 
 ```bash
 $ bandcli query oracle oracle-script 1
-$ curl -X GET http://gyms1.bandchain.org:26657//oracle/oracle_scripts/1
+$ curl -X GET https://api-gm-lb.bandchain.org/oracle/oracle_scripts/1
 {
   "height": "10000",
   "result": {


### PR DESCRIPTION
When I use "http://gyms1.bandchain.org:26657//oracle/oracle_scripts/1" is not working. I try to "https://api-gm-lb.bandchain.org/oracle/oracle_scripts/1" is working.

Could you please review my PR.