### PR TITLE
docs: add evmos to supported blockchain list

### DIFF
--- a/docs/band-standard-dataset/supported-blockchains.md
+++ b/docs/band-standard-dataset/supported-blockchains.md
@@ -17,6 +17,7 @@ We recommend experimenting with using our solution on a test network first befor
 | Ethereum (Kovan) | 0xDA7a001b254CD22e46d3eAB04d937489c93174C3 |               [link](https://kovan.etherscan.io/address/0xDA7a001b254CD22e46d3eAB04d937489c93174C3)                |
 | Celo (Alfajores) | 0x71046b955Cdd96bC54aCa5E66fd69cfb5780f3BB |      [link](https://alfajores-blockscout.celo-testnet.org/address/0x71046b955Cdd96bC54aCa5E66fd69cfb5780f3BB)      |
 | Oasis (Emerald)  | 0xdE2022A8aB68AE86B0CD3Ba5EFa10AaB859d0293 | [link](https://testnet.explorer.emerald.oasis.dev/address/0xdE2022A8aB68AE86B0CD3Ba5EFa10AaB859d0293/transactions) |
+| Evmos            | 0x8c064bCf7C0DA3B3b090BAbFE8f3323534D84d68 |           [link](https://evm.evmos.dev/address/0x8c064bCf7C0DA3B3b090BAbFE8f3323534D84d68/transactions)            |
 
 ## Mainnets
 


### PR DESCRIPTION
- add evmos to the supported blockchain testnet list