### PR TITLE
Fixed wrong parameters example

### DIFF
--- a/docs/custom-script/oracle-script/example.md
+++ b/docs/custom-script/oracle-script/example.md
@@ -70,8 +70,8 @@ const EXTERNAL_ID: i64 = 0;
 #[no_mangle]
 fn prepare_impl(input: Input) {
     oei::ask_external_data(
-        DATA_SOURCE_ID,
         EXTERNAL_ID,
+        DATA_SOURCE_ID,
         format!("{} {}", input.rpc, input.to).as_bytes(),
     );
 }


### PR DESCRIPTION
Fixed parameters for example oracle implementation. Should be ask_external_data(external_id: i64, data_source_id: i64, calldata: &[u8]), here external_id and data_source_id are wrong way around