### PR TITLE
Fix typo

### DIFF
--- a/docs/client-library/bandchain.js/getting-started.md
+++ b/docs/client-library/bandchain.js/getting-started.md
@@ -6,7 +6,7 @@ order: 1
 
 ## Overview
 
-Bandchain.js is a library written in TypeScript used for interacting with BandChain. The library provides classes and methods for convenient to send transactions, query data, OBI encoding, and wallet management.
+Bandchain.js is a library written in TypeScript used for interacting with BandChain. The library provides classes and methods to conveniently send transactions, query data, OBI encoding, and wallet management.
 
 The library is implemented based on [gRPC-web protocol](https://grpc.io/blog/state-of-grpc-web/) which sends HTTP/1.5 or HTTP/2 requests to a gRPC proxy server, before serving them as HTTP/2 to gRPC server.
 


### PR DESCRIPTION
"The library provides classes and methods for convenient and send transacions...". Convenient is used inappropriately. Should be "...provide classes and methods to conveniently send transactions..."